### PR TITLE
MMOCore expansion

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -414,6 +414,16 @@ mmocore-leaves-xp:
 # These professions' levels will be checked before a tree is felled
 mmocore-required-profession-level:
 
+# same as mmocore-trunk-xp, but per-tree
+mmocore-tree-xp:
+#  - global: 1
+#  - woodcutting: 10
+
+# Toggle emulating MMOCore's Block Regen
+# MMOCore's Regen (see MMOCore/professions/mining.yml)
+# MMOCore's "temp-block" option must not be set, otherwise tree will not fell
+mmocore-emulate-regen: false
+
 # Toggle compatibility with MMOCore
 compatibility-mmocore: true
 


### PR DESCRIPTION
- added Option MMOCORE_TREE_XP: similar to trunk/leaves xp, but gives xp once per tree
- removed returns from null checks and put the trunk/leaves xp in an if statement - regen needs this function so we can't return
- added Option MMOCORE_EMULATE_REGEN: allows the user to toggle MMOCore's regen emulation within TreeFeller (in case a user wants it for non-felling only, eg. destroying village farms)